### PR TITLE
Fix #4: Enforcing Accept header on requests because some servers do not obey the spec and return XML by default.

### DIFF
--- a/custom_components/rtetempo/api_worker.py
+++ b/custom_components/rtetempo/api_worker.py
@@ -221,6 +221,9 @@ class APIWorker(threading.Thread):
             "start_date": start_str[:-2] + ":" + start_str[-2:],
             "end_date": end_str[:-2] + ":" + end_str[-2:],
         }
+        headers = {
+            "Accept": "application/json"
+        }
         _LOGGER.debug(
             "Calling %s with start_date as '%s' and end_date as '%s'",
             API_TEMPO_ENDPOINT,
@@ -230,12 +233,12 @@ class APIWorker(threading.Thread):
         # fetch data
         try:
             return self._oauth.get(
-                API_TEMPO_ENDPOINT, params=params, timeout=API_REQ_TIMEOUT
+                API_TEMPO_ENDPOINT, params=params, timeout=API_REQ_TIMEOUT, headers=headers
             )
         except TokenExpiredError:
             self._get_access_token()
             return self._oauth.get(
-                API_TEMPO_ENDPOINT, params=params, timeout=API_REQ_TIMEOUT
+                API_TEMPO_ENDPOINT, params=params, timeout=API_REQ_TIMEOUT, headers=headers
             )
 
     def _update_tempo_days(


### PR DESCRIPTION
I tested that fix on several consecutive restarts and all works fine now. The states are back on restart and I don't see anymore any error in the logs.