### PR TITLE
Feature/opendpe forecast

### DIFF
--- a/custom_components/rtetempo/forecast.py
+++ b/custom_components/rtetempo/forecast.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import datetime
+import logging
+from dataclasses import dataclass
+from typing import List, Optional
+
+import aiohttp
+
+OPEN_DPE_URL = "https://open-dpe.fr/assets/tempo_days_lite.json"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+#   Forecast model
+@dataclass
+class ForecastDay:
+    """Tempo forecast for a given day."""
+
+    date: datetime.date
+    color: str                     # "bleu", "blanc", "rouge" (normalized to lowercase)
+    probability: Optional[float]   # 0.67 for example (for 67%)
+    source: str = "open_dpe"
+
+
+#   Main function (Open-DPE)
+async def async_fetch_opendpe_forecast(
+    session: aiohttp.ClientSession,
+) -> List[ForecastDay]:
+    """Fetch Tempo forecasts from the Open DPE JSON."""
+
+    try:
+        async with session.get(OPEN_DPE_URL, timeout=10) as response:
+            if response.status != 200:
+                _LOGGER.error("Open-DPE: HTTP %s", response.status)
+                return []
+
+            data = await response.json()
+
+    except Exception as exc:
+        _LOGGER.error("Open DPE: erreur lors de la récupération JSON : %s", exc)
+        return []
+
+    forecasts: List[ForecastDay] = []
+
+    for entry in data:
+        try:
+            forecast_date = datetime.datetime.strptime(
+                entry["date"], "%Y-%m-%d"
+            ).date()
+            color = entry.get("couleur", "").lower()
+            prob = entry.get("probability", None)
+
+            forecasts.append(
+                ForecastDay(
+                    date=forecast_date,
+                    color=color,
+                    probability=prob,
+                    source="open_dpe",
+                )
+            )
+
+        except Exception as exc:
+            _LOGGER.warning("Open DPE: ligne ignorée (%s) : %s", exc, entry)
+            continue
+
+    return forecasts

--- a/custom_components/rtetempo/forecast_coordinator.py
+++ b/custom_components/rtetempo/forecast_coordinator.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import List
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_time_change
+
+from .forecast import ForecastDay, async_fetch_opendpe_forecast
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ForecastCoordinator(DataUpdateCoordinator[List[ForecastDay]]):
+    """Coordinator in charge of fetching Open-DPE forecasts."""
+
+    def __init__(self, hass: HomeAssistant):
+        """Initializing the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Tempo Forecast Coordinator",
+            update_interval=timedelta(hours=6),  # refresh every 6 hours
+        )
+
+        self.hass = hass
+        self.session = async_get_clientsession(hass)
+
+        # Daily update at 07:00 (JSON is updated around 06:00)
+        async_track_time_change(
+            hass,
+            self._scheduled_refresh,
+            hour=7,
+            minute=0,
+            second=0,
+        )
+
+        _LOGGER.debug(
+            "ForecastCoordinator initialisé : refresh quotidien programmé à 07:00 + intervalle 6h"
+        )
+
+    async def _scheduled_refresh(self, now):
+        """Update at 07:00 every day."""
+        _LOGGER.debug("Open DPE: lancement du refresh programmé à 07:00")
+        await self.async_request_refresh()
+
+    async def _async_update_data(self) -> List[ForecastDay]:
+        """Open DPE data recovery."""
+        try:
+            forecasts = await async_fetch_opendpe_forecast(self.session)
+            _LOGGER.debug("Open DPE: %s jours récupérés", len(forecasts))
+            return forecasts
+
+        except Exception as exc:
+            _LOGGER.error("Open DPE: erreur lors de la mise à jour: %s", exc)
+            raise UpdateFailed(f"Erreur mise à jour des prévisions Open DPE: {exc}")

--- a/custom_components/rtetempo/forecast_coordinator.py
+++ b/custom_components/rtetempo/forecast_coordinator.py
@@ -29,7 +29,7 @@ class ForecastCoordinator(DataUpdateCoordinator[List[ForecastDay]]):
         self.hass = hass
         self.session = async_get_clientsession(hass)
 
-        # Daily update at 07:00 (JSON is updated around 06:00)
+        # Daily uptade after midnight then every 6 hours (JSON is updated around 06:00)
         async_track_time_change(
             hass,
             self._scheduled_refresh,
@@ -57,3 +57,4 @@ class ForecastCoordinator(DataUpdateCoordinator[List[ForecastDay]]):
         except Exception as exc:
             _LOGGER.error("Open DPE: erreur lors de la mise à jour: %s", exc)
             raise UpdateFailed(f"Erreur mise à jour des prévisions Open DPE: {exc}")
+

--- a/custom_components/rtetempo/sensor.py
+++ b/custom_components/rtetempo/sensor.py
@@ -86,12 +86,16 @@ async def async_setup_entry(
     #   Add forecast sensors from Open DPE
     forecast_coordinator = ForecastCoordinator(hass)
     await forecast_coordinator.async_config_entry_first_refresh()
-
+    
     NUM_FORECAST_DAYS = 7  # J+1 à J+7
-
-    for index in range(NUM_FORECAST_DAYS):
-        sensors.append(OpenDPEForecastSensor(forecast_coordinator, index))
-
+    
+    # Skip index 0 (J+1) because RTE provides the official J+1 sensor
+    for index in range(1, NUM_FORECAST_DAYS):
+        # Text version
+        sensors.append(OpenDPEForecastSensor(forecast_coordinator, index, visual=False))
+        # Visual version (emoji)
+        sensors.append(OpenDPEForecastSensor(forecast_coordinator, index, visual=True))
+        
     # Add the entities to HA
     async_add_entities(sensors, True)
 

--- a/custom_components/rtetempo/sensor.py
+++ b/custom_components/rtetempo/sensor.py
@@ -43,6 +43,10 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
+# Importing coordinator and sensors for forecast data
+from .forecast_coordinator import ForecastCoordinator
+from .sensor_forecast import OpenDPEForecastSensor
+
 # config flow setup
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -78,9 +82,18 @@ async def async_setup_entry(
         NextCycleTime(config_entry.entry_id),
         OffPeakChangeTime(config_entry.entry_id),
     ]
+
+    #   Add forecast sensors from Open DPE
+    forecast_coordinator = ForecastCoordinator(hass)
+    await forecast_coordinator.async_config_entry_first_refresh()
+
+    NUM_FORECAST_DAYS = 7  # J+1 à J+7
+
+    for index in range(NUM_FORECAST_DAYS):
+        sensors.append(OpenDPEForecastSensor(forecast_coordinator, index))
+
     # Add the entities to HA
     async_add_entities(sensors, True)
-
 
 class CurrentColor(SensorEntity):
     """Current Color Sensor Entity."""

--- a/custom_components/rtetempo/sensor_forecast.py
+++ b/custom_components/rtetempo/sensor_forecast.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.entity import DeviceInfo
+
+from .forecast_coordinator import ForecastCoordinator
+from .forecast import ForecastDay
+from .const import (
+    DOMAIN,
+    DEVICE_NAME,
+    DEVICE_MANUFACTURER,
+    DEVICE_MODEL,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OpenDPEForecastSensor(CoordinatorEntity, SensorEntity):
+    """Forecast sensor for a given day (J+1, J+2, …)."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_icon = "mdi:calendar"
+
+    def __init__(self, coordinator: ForecastCoordinator, index: int):
+        """
+        index = 0 → J+1
+        index = 1 → J+2
+        etc.
+        """
+        super().__init__(coordinator)
+
+        self.index = index
+
+        self._attr_name = f"OpenDPE J{index + 1}"
+        self._attr_unique_id = f"{DOMAIN}_forecast_opendpe_j{index + 1}"
+
+        # Valeurs possibles
+        self._attr_options = ["bleu", "blanc", "rouge", "inconnu"]
+
+        self._attr_native_value: Optional[str] = None
+        self._attr_extra_state_attributes = {}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Home Assistant device information."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, "forecast")},
+            name="RTE Tempo Forecast",
+            manufacturer=DEVICE_MANUFACTURER,
+            model=DEVICE_MODEL,
+        )
+
+    @property
+    def available(self) -> bool:
+        """The sensor is available if we have enough data."""
+        data = self.coordinator.data
+        return data is not None and len(data) > self.index
+
+    def _handle_coordinator_update(self) -> None:
+        """Synchronize the sensor state with the coordinator data."""
+        data = self.coordinator.data
+
+        if not data or len(data) <= self.index:
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {}
+            self.async_write_ha_state()
+            return
+
+        forecast: ForecastDay = data[self.index]
+
+        # Couleur principale
+        color = forecast.color.lower()
+        if color not in ["bleu", "blanc", "rouge"]:
+            color = "inconnu"
+
+        self._attr_native_value = color
+
+        # Attributs supplémentaires
+        self._attr_extra_state_attributes = {
+            "date": forecast.date.isoformat(),
+            "probabilité": forecast.probability,
+            ATTR_ATTRIBUTION: "Données Tempo : Open DPE (https://open-dpe.fr)",
+        }
+
+        self.async_write_ha_state()


### PR DESCRIPTION
**Purpose**

This PR adds weekly Tempo color forecasts (J+2 to J+7) to the existing RTE Tempo integration, using data publicly provided by OpenDPE (https://open-dpe.fr).
These forecasts are complementary to the official RTE API, which only exposes current and next-day colors.

The goal is to provide Home Assistant users with a reliable week-ahead view of Tempo colors, without modifying or interfering with the official RTE data.

**Summary of the enhancement**

Adds a `ForecastCoordinator` that retrieves forecast data from the OpenDPE JSON endpoint.
Adds a dedicated OpenDPE forecast device with 6 forecast sensors: `sensor.rte_tempoforecast_opendpe_j2` to `sensor.rte_tempoforecast_opendpe_j7`.
For each forecasted day, both a text sensor and a visual one are created, in order to maintain consistency with the original integration.

Forecast refresh schedule :

- once at Home Assistant startup
- daily at 07:00 (data is updated around 06:00 on OpenDPE)
- every 6 hours afterward

**Clean separation:**

No changes to existing entities from the original integration
No override of official RTE values (J+1 remains the official RTE next day color)
OpenDPE forecast sensors are clearly isolated in their own device
Includes proper attribution: "_Données prévisionnelles : Open DPE (https://open-dpe.fr)_"

**Files modified**

**sensor.py**
→ adds the `ForecastCoordinator` initialization and the loop that creates the weekly forecast sensors (text + visual).
No existing files modified beyond this.

Additionnal new files introduced : `forecast.py`, `forecast_coordinator.py`, `sensor_forecast.py`

**API source**

Forecasts come from:
https://open-dpe.fr/assets/tempo_days_lite.json

This endpoint is stable, public, free, and the owner has explicitly confirmed that the data will remain open and free,
no rate limits are planned (reasonable polling recommended), format and URL are stable, attribution is welcome.

**Rationale**

Many Tempo users want a weekly overview of expected colors for planning heating, EV charging, and household energy usage.
OpenDPE already provides reliable daily forecasts up to 7 days ahead.
The feature integrates smoothly without affecting users who only want official RTE data.
It significantly increases the usefulness of the Tempo integration while remaining lightweight (a single JSON fetch every few hours).

**User documentation**

A detailed example of a Lovelace card using the new forecast sensors is available here:
https://forum.hacf.fr/t/carte-des-jours-tempo-avec-previsions-pour-la-semaine/71112

**Backward compatibility**

No breaking change
No renamed or removed entities
No change to RTE API logic
Only new sensors added

**Testing**

This integration has been tested on: Home Assistant OS (2025.11.3)
Clean configuration
Migration from previous versions of RTE Tempo
Fresh install
Multiple reboots
Network timeouts from OpenDPE
Daily and interval updates

All behaviors are stable and predictable.